### PR TITLE
getScrollbarSize width error

### DIFF
--- a/source/stable/jquery.layout.js
+++ b/source/stable/jquery.layout.js
@@ -324,7 +324,7 @@ $.layout = {
 ,	scrollbarHeight:	function () { return window.scrollbarHeight || $.layout.getScrollbarSize('height'); }
 ,	getScrollbarSize:	function (dim) {
 		var $c	= $('<div style="position: absolute; top: -10000px; left: -10000px; width: 100px; height: 100px; overflow: scroll;"></div>').appendTo("body");
-		var d	= { width: $c.css("width") - $c[0].clientWidth, height: $c.height() - $c[0].clientHeight };
+		var d	= { width: $c.width() - $c[0].clientWidth, height: $c.height() - $c[0].clientHeight };
 		$c.remove();
 		window.scrollbarWidth	= d.width;
 		window.scrollbarHeight	= d.height;


### PR DESCRIPTION
Currently the scroll bar width is NaN. This fixes that issue.
jQuery css('width') returns the unit type with the numeric value, width() does not. 
