### PR TITLE
Support installing via Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,8 @@
 	],
 	"main": [
 		"source/stable/jquery.layout.js",
-		"source/stable/jquery.layout.min.js"
+		"source/stable/jquery.layout.min.js",
+		"source/stable/layout-default.css"
 	],
 	"ignore": [
 		".*",


### PR DESCRIPTION
This change adds `bower.json` descriptor (with package name `jquery-ui-layout`) which is a copy of `layout.jquery.json` with `main` and `ignore` properties added (and `version` increased to v1.4.4 to be able to test it). [Bower](http://bower.io/) already has your project indexed as "jquery-layout", "jquery-ui-layout" and "jquery-ui-layout-bower" (this links to my fork of your repository). If you decide to merge this into your repository - I will remove my Bower package ("jquery-ui-layout-bower") and will be able to switch to one of the former (I guess they will start working as soon as there is `bower.json` in your repository).
