### PR TITLE
Add workaround to properly display overflowing child elements of panes

### DIFF
--- a/layout.jquery.json
+++ b/layout.jquery.json
@@ -2,7 +2,7 @@
 	"name": "layout",
 	"title": "UI Layout",
 	"description": "Create advanced UI layouts with sizable, collapsible, nested panels and tons of options. Layout can create any UI look you want; from simple headers or sidebars to a complex application with toolbars, menus, help-panels, status bars, sub-forms, etc. Integrates with and enhances other UI widgets, like tabs, accordions and dialogs, to create rich interfaces.",
-	"version": "1.4.3",
+	"version": "1.4.5",
 	"keywords": [
 		"ui",
 		"layout"

--- a/source/stable/jquery.layout.js
+++ b/source/stable/jquery.layout.js
@@ -35,10 +35,11 @@
 ;(function ($) {
 
 // alias Math methods - used a lot!
+/*jshint -W014 */
 var	min		= Math.min
 ,	max		= Math.max
 ,	round	= Math.floor
-
+/*jshint +W014 */
 ,	isStr	=  function (v) { return $.type(v) === "string"; }
 
 	/**
@@ -1829,7 +1830,7 @@ $.fn.layout = function (opts) {
 		,	$parent, n
 		;
 		// sC = state.container
-		sC.selector = $N.selector.split(".slice")[0];
+		// sC.selector = $N.selector.split(".slice")[0];
 		sC.ref		= (o.name ? o.name +' layout / ' : '') + tag + (id ? "#"+id : cls ? '.['+cls+']' : ''); // used in messages
 		sC.isBody	= (tag === "BODY");
 

--- a/source/stable/jquery.layout_and_plugins.js
+++ b/source/stable/jquery.layout_and_plugins.js
@@ -1829,7 +1829,7 @@ $.fn.layout = function (opts) {
 		,	$parent, n
 		;
 		// sC = state.container
-		sC.selector = $N.selector.split(".slice")[0];
+		// sC.selector = $N.selector.split(".slice")[0];
 		sC.ref		= (o.name ? o.name +' layout / ' : '') + tag + (id ? "#"+id : cls ? '.['+cls+']' : ''); // used in messages
 		sC.isBody	= (tag === "BODY");
 

--- a/source/stable/layout-default.css
+++ b/source/stable/layout-default.css
@@ -32,6 +32,11 @@ body {
 	border:		1px solid #BBB;
 	padding:	10px; 
 	overflow:	auto;
+	/* don't create a new stacking context, so that overflowing child elements of a 'pane'
+	   (for example: popups, dropdown lists, tooltips) are correctly displayed
+		 in front of other 'panes' WHILE the mouse IS NEITHER over the 'pane' NOR over its child elements.
+		 */
+	z-index: auto !important;
 	/* DO NOT add scrolling (or padding) to 'panes' that have a content-div,
 	   otherwise you may get double-scrollbars - on the pane AND on the content-div
 	   - use ui-layout-wrapper class if pane has a content-div

--- a/source/stable/layout-default.css
+++ b/source/stable/layout-default.css
@@ -1,9 +1,9 @@
 /*
  * Default Layout Theme
  *
- * Created for jquery.layout 
+ * Created for jquery.layout
  *
- * Copyright (c) 2010 
+ * Copyright (c) 2010
  *   Fabrizio Balliano (http://www.fabrizioballiano.net)
  *   Kevin Dalman (http://allpro.net)
  *
@@ -28,11 +28,11 @@ body {
  *	PANES & CONTENT-DIVs
  */
 .ui-layout-pane { /* all 'panes' */
-	background:	#FFF; 
+	background:	#FFF;
 	border:		1px solid #BBB;
-	padding:	10px; 
+	padding:	10px;
 	overflow:	auto;
-	/* don't create a new stacking context, so that overflowing child elements of a 'pane'
+	/* don't create a new stacking context, so that overflowing child elements of a 'pane' abcded
 	   (for example: popups, dropdown lists, tooltips) are correctly displayed
 		 in front of other 'panes' WHILE the mouse IS NEITHER over the 'pane' NOR over its child elements.
 		 */
@@ -115,7 +115,7 @@ body {
 			opacity: 1.00; /* on-hover, show the resizer-bar normally */
 			filter:  alpha(opacity=100);
 		}
-		/* sliding resizer - add 'outside-border' to resizer on-hover 
+		/* sliding resizer - add 'outside-border' to resizer on-hover
 		 * this sample illustrates how to target specific panes and states */
 		.ui-layout-resizer-north-sliding-hover	{ border-bottom-width:	1px; }
 		.ui-layout-resizer-south-sliding-hover	{ border-top-width:		1px; }
@@ -164,7 +164,7 @@ body {
 
 /*
  *	PANE-MASKS
- *	these styles are hard-coded on mask elems, but are also 
+ *	these styles are hard-coded on mask elems, but are also
  *	included here as !important to ensure will overrides any generic styles
  */
 .ui-layout-mask {


### PR DESCRIPTION
The workaround preserves the initial 'auto' z-index of 'panes', so that
it is possible to keep many overflowing child elements of 'panes'
visible in front of all other 'panes' while the mouse is neither over
the 'pane' or its children;

Actually, this solution replaces handing of z-indexes via:
allowOverflow( elem_or_pane )
resetOverflow( elem_or_pane )
showOverflowOnHover 
... in most of the standard use cases.
