### PR TITLE
maskIframesOnResize=true bug work-around

### DIFF
--- a/source/stable/jquery.layout.js
+++ b/source/stable/jquery.layout.js
@@ -2804,7 +2804,7 @@ $.fn.layout = function (opts) {
 		,	s		= state[pane]
 		;
 		// only masks over an IFRAME-pane need manual resizing
-		if (s.tagName == "IFRAME" && s.isVisible) // no need to mask closed/hidden panes
+		if (s && s.tagName == "IFRAME" && s.isVisible) // no need to mask closed/hidden panes
 			$M.css({
 				top:	s.offsetTop
 			,	left:	s.offsetLeft


### PR DESCRIPTION
…ng jQuery Layout with option[maskIframesOnResize = true], resizing the pane, replacing the HTML-content in pane and then resizing it again. In that case "s" was undefined which lead to resize-crashes. This is only a work-around until the root problem is resolved, I think that it would be great with a "RefreshDOM()" method that refreshes tha pane-state that you would call after replacing the pane-content.